### PR TITLE
fix: second module should be at 10:00 AM

### DIFF
--- a/src/Util/util.js
+++ b/src/Util/util.js
@@ -13,7 +13,7 @@ const NUMERO_MODULOS = 8;
 
 const HORA_MODULOS = [
   '08:30',
-  '10:30',
+  '10:00',
   '11:30',
   '14:00',
   '15:30',


### PR DESCRIPTION
Por alguna razón el segundo módulo en el sistema está configurado a las 10:30 AM, siendo que debería ser a las 10:00 AM.

![image](https://user-images.githubusercontent.com/4694408/156303882-1775eeb9-3aea-4276-93ef-27b90d42a81c.png)
