### PR TITLE
chore: dumped actions & node versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@4.4.3
         with:
           folder: dist
           branch: gh-pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "horario-uc",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "horario-uc",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@aurmeneta/buscacursos-uc": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "homepage": "http://aurmeneta.github.io/HorarioUC",
   "engines": {
-    "node": "16.x",
-    "npm": "8.x"
+    "node": "18.x",
+    "npm": "9.x"
   },
   "dependencies": {
     "@aurmeneta/buscacursos-uc": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horario-uc",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Planificador de cursos de la UC.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
- Github Autodeploy Action version dumped.
- Changed default node version to 18.x and npm to 9.x